### PR TITLE
Corrected misuse of classes, added missing imports

### DIFF
--- a/C#/FriedEgg.cs
+++ b/C#/FriedEgg.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 
 namespace Recipes {
     public class FriedEgg : Recipe {
@@ -20,7 +22,7 @@ namespace Recipes {
             _spices.Add(new Pepper());
         }
 
-        public void Cook(Utensil pan, Liquid oil, Utensil spoon) {
+        public void Cook(Appliance pan, Liquid oil, Cutlery spoon) {
             Liquid oilForEggs = spoon.Take(oil, 3);
             pan.Add(oilForEggs);
 
@@ -32,7 +34,7 @@ namespace Recipes {
             pan.OnFoodDone += PutInPlate;
         }
         
-        public void PutInPlate(Utensil pan, int foodIndex) {
+        public void PutInPlate(Appliance pan, int foodIndex) {
             Egg friedEgg = pan.Remove(foodIndex);
 
             for (int i = 0; i < _spices.Count; ++i) {

--- a/C#/RiceAndSausages.cs
+++ b/C#/RiceAndSausages.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 
 namespace Recipes {
     public class RiceAndSausages : Recipe {
@@ -19,7 +21,7 @@ namespace Recipes {
             }
         }
 
-        public void Cook(Utensil riceMaker, Utensil pan, Liquid oil, Cutlery spoon, Cutlery fork) {
+        public void Cook(Appliance riceMaker, Appliance pan, Liquid oil, Cutlery spoon, Cutlery fork) {
             riceMaker.Add(new Rice(_riceGrams));
             riceMaker.Cook();
             riceMaker.OnDone += TakeRiceOut;
@@ -33,7 +35,7 @@ namespace Recipes {
             pan.OnFoodDone += TakeSausagesOut;
         }
 
-        private void TakeRiceOut(Utensil riceMaker) {
+        private void TakeRiceOut(Appliance riceMaker) {
             _plate.Add(riceMaker.Empty());
             _riceDone = true;
 
@@ -42,7 +44,7 @@ namespace Recipes {
             }
         }
 
-        public void TakeSausagesOut(Utensil pan, int foodIndex) {
+        public void TakeSausagesOut(Appliance pan, int foodIndex) {
             _plate.Add(pan.Remove(foodIndex));
             _plate.Add(_breadSlices.Pop());
             _sausagesDone = true;


### PR DESCRIPTION
The two existing recipes had some classes named as _Utensil_ that should have been _Appliance_.

Imports of system and generic collections were missing.